### PR TITLE
feat(copy): added new argument which can be passed called use native copy which defaults to nodejs copy recursive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## [0.8.1](https://github.com/rxdi/firelink/compare/v0.8.0...v0.8.1) (2022-10-25)
+
+
+### Features
+
+* **copy:** added new argument which can be passed called use native copy which defaults to nodejs copy recursive ([d6d2c52](https://github.com/rxdi/firelink/commit/d6d2c522fc71cced8053b352614ac4891abd2875))
+
+
+
 # [0.8.0](https://github.com/rxdi/firelink/compare/v0.7.75...v0.8.0) (2022-03-16)
 
 

--- a/README.md
+++ b/README.md
@@ -135,6 +135,19 @@ Revert the changes made inside `package.json`
 firelink --no-runner --revert-changes
 ```
 
+#### Native Nodejs Copy instead of `rsync`
+
+This argument is introduced due to recent issue that has being made https://github.com/rxdi/firelink/issues/55
+It appears that in the newest nodejs 16 docker image rsync package is missing
+
+There is a way to specify which runner firelink will use
+when specify `--use-native-copy` it will default to nodejs implementation of recursive copy the files
+By default in windows environment this is the main method used to copy files since `rsync` is missing in windows
+
+```
+firelink --use-native-copy
+```
+
 # Configuration
 
 Default runner is command `firebase` but you can change it for example to `gcloud` or `serverless` by defining `fireConfig` inside `package.json`
@@ -145,7 +158,8 @@ Default runner is command `firebase` but you can change it for example to `gclou
     "runner": "firebase",
     "outFolderName": ".packages",
     "outFolderLocation": ".",
-    "excludes": ["node_modules"]
+    "excludes": ["node_modules"],
+    "useNativeCopy": true
   }
 }
 ```

--- a/example/package.json
+++ b/example/package.json
@@ -12,6 +12,7 @@
     "outFolderLocation": ".",
     "excludes": [
       "node_modules"
-    ]
+    ],
+    "useNativeCopy": true
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rxdi/firelink",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rxdi/firelink",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "bin": {
     "firelink": "./dist/main.js"
   },

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "main": "./dist/index.js",
   "scripts": {
-    "build": "npx parcel@1.12.3 build ./src/main.ts --experimental-scope-hoisting --target node",
+    "build": "parcel build ./src/main.ts --experimental-scope-hoisting --target node",
     "build-binary": "npx gapi build --single-executable && mkdir binaries && npm run copy-binaries",
     "build-all": "npm run build-binary && rm -rf dist && npm run build",
     "test": "npx jest",

--- a/src/create-virtual-symlink.spec.ts
+++ b/src/create-virtual-symlink.spec.ts
@@ -12,7 +12,8 @@ jest.mock('./helpers/build-packages', () => ({
   buildPackages: async (...args: unknown[]) => mockBuildPackages(...args),
 }));
 jest.mock('./helpers/copy-packages', () => ({
-  copyPackages: (...args: unknown[]) => mockCopyPackages(...args),
+  copyPackages: (...args: unknown[]) => () => () => () => () =>
+    mockCopyPackages(...args),
 }));
 jest.mock('./helpers/exit-handler', () => ({
   exitHandler: (...args: unknown[]) => mockExitHandler(...args),

--- a/src/create-virtual-symlink.ts
+++ b/src/create-virtual-symlink.ts
@@ -45,7 +45,9 @@ export async function createVirtualSymlink(
       dep,
       folder: linkedDepndencies[dep],
     }));
-    await copyPackages(dependencies, outFolder, outFolderName, excludes);
+    await copyPackages(dependencies)(outFolder)(outFolderName)(excludes)(
+      includes(Tasks.USE_NATIVE_COPY) || packageJson.fireConfig.useNativeCopy,
+    );
     if (includes(Tasks.BUILD)) {
       try {
         await buildPackages(outFolder, outFolderName);

--- a/src/helpers/copy-packages.ts
+++ b/src/helpers/copy-packages.ts
@@ -26,19 +26,20 @@ function copyOther(
   });
 }
 
-export function copyPackages(
-  dependencies: DependenciesLink[],
-  outFolder: string,
-  outFolderName: string,
-  excludes: string[],
-) {
-  return Promise.all(
-    dependencies.map(({ folder }) =>
-      isWin
-        ? FolderSync.copyFolderRecursive(folder, join(outFolder, outFolderName))
-        : copyOther(folder, outFolder, outFolderName, excludes),
-    ),
-  );
+export function copyPackages(dependencies: DependenciesLink[]) {
+  return (outFolder: string) => (outFolderName: string) => (
+    excludes: string[],
+  ) => (nativeCopyEnabled?: boolean) =>
+    Promise.all(
+      dependencies.map(({ folder }) =>
+        nativeCopyEnabled || isWin
+          ? FolderSync.copyFolderRecursive(
+              folder,
+              join(outFolder, outFolderName),
+            )
+          : copyOther(folder, outFolder, outFolderName, excludes),
+      ),
+    );
 }
 
 /* Cannot make it work to behave the same as rsync in windows for now */

--- a/src/injection-tokens.ts
+++ b/src/injection-tokens.ts
@@ -4,6 +4,7 @@ export interface FireLinkConfig {
   outFolderName?: string;
   excludes?: string[];
   excludesFileName?: string;
+  useNativeCopy?: boolean;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -37,6 +38,7 @@ export enum Tasks {
   BUILD = '--buildCommand',
   LEAVE_CHANGES = '--leave-changes',
   NO_RUNNER = '--no-runner',
+  USE_NATIVE_COPY = '--use-native-copy',
 }
 
 export interface DependenciesLink {


### PR DESCRIPTION
# [Issue](https://github.com/rxdi/firelink/issues/55)

# Description

Introduced new argument to pass `--use-native-copy` which will fallback to nodejs implementation of recursive copy files and folders instead of default one `rsync`.
This change is introduced in order for people which doesn't have `rsync` installed to use `firelink` as intended.

Caution this implementation is not so efficient and it may take more time in comparison to `rsync

## Type of change

-   [x] Non Breaking change

