### PR TITLE
fix(rsync): added --force argument in order to test the idempotency of rsync

### DIFF
--- a/src/helpers/copy-packages.ts
+++ b/src/helpers/copy-packages.ts
@@ -14,6 +14,7 @@ function copyOther(
     command: 'rsync',
     args: [
       '-r',
+      '--force',
       ...(excludes
         ? excludes.reduce(
             (prev, curr) => [...prev, '--exclude', curr],


### PR DESCRIPTION
# [Issue](https://github.com/rxdi/firelink/issues/56)

# Description

This PR represents adding a `--force` argument to `rsync` in order to not throw error that file exists

```
rsync: mkdir "/builds/XXXXXX/./.packages" failed: File exists (17)
rsync error: error in file IO (code 11) at main.c(682) [Receiver=3.1.3]
```


## Type of change

-   [x] Breaking change

# Checklist:

-   [x] Added `--force` argument inside `copy-packages.ts` 

