### PR TITLE
fix(): removed namespacing and instead we use provided folder from fireDependencies the tool resolves now any package not only monorepo packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,6 @@ There are multiple binaries for `mac`, `windows` and `linux`
 There is only one tested in `linux` so keep in mind that for `mac` and `windows` may not work!
 If the binaries don't work in `mac` or `windows` please install it via `npm` globally with `npm i -g @rxdi/firelink`
 
-The tool assumes `@group/package-name` naming convention
-
 ## Usage
 
 #### Add `fireDependencies` inside `package.json`
@@ -172,6 +170,8 @@ so we want to not waste time duplicating node modules
 Equivalent of excludes inside package.json `.fireignore` can be specified as a file inside a directory where the command `firelink` will be executed. `.fireignore` behaviour is the same as `.gitignore`
 
 If you do not wish to use `.fireignore` file name the name can be specified from `fireConfig.excludesFileName`
+
+You can pass `--runner dir` argument to the command which will override the default runner `firebase`
 
 By default packages will be saved in `.packages` folder and `current` directory will be used
 U can change that by specifiyng properties `outFolderName` and `outFolderLocation` inside `fireConfig`

--- a/src/create-virtual-symlink.ts
+++ b/src/create-virtual-symlink.ts
@@ -1,4 +1,4 @@
-import { includes } from './helpers/args-extractors';
+import { includes, nextOrDefault } from './helpers/args-extractors';
 import { buildPackages } from './helpers/build-packages';
 import { copyPackages } from './helpers/copy-packages';
 import { exitHandler } from './helpers/exit-handler';
@@ -22,7 +22,11 @@ export async function createVirtualSymlink(
 ) {
   packageJson.fireConfig = packageJson.fireConfig || ({} as FireLinkConfig);
   let successStatus = false;
-  const runner = packageJson.fireConfig.runner || DEFAULT_RUNNER;
+  const runner =
+    nextOrDefault(Tasks.RUNNER) ||
+    packageJson.fireConfig.runner ||
+    DEFAULT_RUNNER;
+
   const excludes = [
     ...(packageJson.fireConfig.excludes || []),
     ...(await readExcludes(
@@ -67,7 +71,7 @@ export async function createVirtualSymlink(
       ),
     );
 
-    await modifyJson(packageJson, dependencies, outFolder, outFolderName);
+    await modifyJson(packageJson, dependencies);
   }
 
   try {

--- a/src/helpers/args-extractors.ts
+++ b/src/helpers/args-extractors.ts
@@ -1,12 +1,10 @@
-import { Tasks } from '../injection-tokens';
-
 export const includes = (i: string) => process.argv.toString().includes(i);
 export const nextOrDefault = (
   i: string,
-  fb: boolean | string = true,
+  fb?: string,
   type = (p: string) => p,
 ) => {
-  if (process.argv.toString().includes(Tasks[i])) {
+  if (process.argv.toString().includes(i)) {
     const isNextArgumentPresent = process.argv[process.argv.indexOf(i) + 1];
     if (!isNextArgumentPresent) {
       return fb;

--- a/src/helpers/modify-json.ts
+++ b/src/helpers/modify-json.ts
@@ -10,13 +10,9 @@ import {
 export async function modifyJson(
   packageJson: PackageJson,
   dependencies: DependenciesLink[],
-  outFolder: string,
-  outFolderName: string,
 ) {
-  for (const { dep } of dependencies) {
-    packageJson.dependencies[dep] = `file:${outFolder}/${outFolderName}/${
-      dep.includes('/') ? dep.split('/')[1] : dep
-    }`;
+  for (const { dep, folder } of dependencies) {
+    packageJson.dependencies[dep] = `file:${folder}`;
   }
   await promisify(writeFile)(
     WorkingFiles.PACKAGE_JSON,

--- a/src/injection-tokens.ts
+++ b/src/injection-tokens.ts
@@ -39,6 +39,7 @@ export enum Tasks {
   LEAVE_CHANGES = '--leave-changes',
   NO_RUNNER = '--no-runner',
   USE_NATIVE_COPY = '--use-native-copy',
+  RUNNER = '--runner',
 }
 
 export interface DependenciesLink {


### PR DESCRIPTION
# [Issue](https://github.com/rxdi/firelink/issues/67)

# Description

The tool now assumes not only namespaced packages but instead every npm package.
For some reason the specified folder for the dependency was not used but instead dependencies was splitted and we take the directory based on the name of the package. This was not intended bug the initial purpose of this library was  to work with every package not only namespaced.

## Type of change

-   [x] Non Breaking change
